### PR TITLE
Fixed the display of open e-relative shapes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ function App() {
             <Fretboard 
               rootNote={rootNote} 
               type={displayType === 'scale' ? scaleType : arpeggioType}
-              frets={15} 
+              frets={16} 
               useNashville={useNashville}
               isArpeggio={displayType === 'arpeggio'}
               cagedPattern={cagedPattern}

--- a/src/components/fret_markers/FretMarkers.tsx
+++ b/src/components/fret_markers/FretMarkers.tsx
@@ -1,5 +1,5 @@
 import { Box, styled } from '@mui/material';
-import { Marker } from '../marker';
+import { Marker } from 'components';
 
 const FretMarkersContainer = styled(Box, {
     shouldForwardProp: prop => prop !== 'isDouble'

--- a/src/components/fretboard/Fretboard.tsx
+++ b/src/components/fretboard/Fretboard.tsx
@@ -76,10 +76,12 @@ export const Fretboard: React.FC<FretboardProps> = ({
   const isInERelativePattern = (stringNum: number, fretNum: number) => {
     if (!eRelativePattern) return false;
 
-    const selectedERelativeShape: ERelativePatternMapped = getSelectedERelativeShape(rootNote, 'major' as ScaleType, eRelativePattern);
+    const selectedERelativeShapes: ERelativePatternMapped[] = getSelectedERelativeShape(rootNote, 'major' as ScaleType, eRelativePattern);
 
-    return selectedERelativeShape.fretPositions.some((pos: PatternPosition) => {
-      return pos.string === stringNum && pos.fret === fretNum;
+    return selectedERelativeShapes.some((selectedERelativeShape: ERelativePatternMapped) => {
+      return selectedERelativeShape.fretPositions.some((pos: PatternPosition) => {
+        return pos.string === stringNum && pos.fret === fretNum;
+      });
     });
   };
 

--- a/src/components/string/String.tsx
+++ b/src/components/string/String.tsx
@@ -2,12 +2,12 @@ import { Box, styled } from '@mui/material';
 import { GuitarTheme } from 'themes';
 
 export const String = styled(Box)<{ orientation?: 'horizontal' | 'vertical' }>(({ theme, orientation = 'horizontal' }) => ({
-    display: 'flex',
-    flexDirection: orientation === 'vertical' ? 'column' : 'row',
-    height: orientation === 'vertical' ? 'auto' : 40,
-    width: orientation === 'vertical' ? 40 : 'auto',
-    gap: 1,
-    position: 'relative',
-    borderBottom: orientation === 'vertical' ? 'none' : `2px solid ${(theme as GuitarTheme).fretboard.string}`,
-    borderRight: orientation === 'vertical' ? `2px solid ${(theme as GuitarTheme).fretboard.string}` : 'none',
-  })); 
+  display: 'flex',
+  flexDirection: orientation === 'vertical' ? 'column' : 'row',
+  height: orientation === 'vertical' ? 'auto' : 40,
+  width: orientation === 'vertical' ? 40 : 'auto',
+  gap: 1,
+  position: 'relative',
+  borderBottom: orientation === 'vertical' ? 'none' : `2px solid ${(theme as GuitarTheme).fretboard.string}`,
+  borderRight: orientation === 'vertical' ? `2px solid ${(theme as GuitarTheme).fretboard.string}` : 'none',
+})); 

--- a/src/patterns/eRelativePatterns.ts
+++ b/src/patterns/eRelativePatterns.ts
@@ -131,7 +131,6 @@ export const E_RELATIVE_SHAPES: Record<string, ERelativeShape> = {
   
         { string: 3, fret: 1 }, 
         { string: 3, fret: 2 }, 
-        { string: 3, fret: 4 }, 
   
         { string: 2, fret: 0 }, 
         { string: 2, fret: 2 }, 
@@ -229,9 +228,9 @@ export const getIntervalStepsForPatternShape = (eRoot: number, scaleType: ScaleT
   return sortedIntervalSteps;
 }
 
-export const getSelectedERelativeShape = (rootOfScale: Note, scaleType: ScaleType, eRelativePattern: ERelativePattern): ERelativePatternMapped => {
+export const getSelectedERelativeShape = (rootOfScale: Note, scaleType: ScaleType, eRelativePattern: ERelativePattern): ERelativePatternMapped[] => {
   const patterns: ERelativePatternMapped[] = getERelativeShapesInScale(rootOfScale, scaleType);
-  return patterns.find(pattern => pattern.name === eRelativePattern) as ERelativePatternMapped;
+  return patterns.filter(pattern => pattern.name === eRelativePattern) as ERelativePatternMapped[];
 }
 
 export const getERelativeShapesInScale = (rootOfScale: Note, scaleType: ScaleType): ERelativePatternMapped[] => {


### PR DESCRIPTION
- Expanded the fretboard display to 16 frets (from 15) to make room for the last pattern that sometimes reaches fret 16.
- Previously the open e-relative shape was not displaying when selected and only the right-most closed pattern was shown.  Fixed the logic to allow for all patterns to highlight when selected when appearing more than once.  
- Fixed the 5A pattern to exclude the 2 note on the third string, which doesn't belong to the pattern
