### PR TITLE
STRUM-14

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,53 @@ yarn test
 Today, that gets you one passing and 3 failing tests.  Testing is often a developer's last priority, including that of yours truly.
 
 Stay tuned!
+
+## Future direction and research
+
+### Microservices architecture
+
+At some point in the near future, all of this will be deployed to the cloud and assigned to a 
+domain.  For now I am still iterating over all the POCs to provide a minimum viable product.
+
+This will be deployed on AWS and to my way of thinking today this will involve combining AWS with
+Docker in a microservices architecture/layout.  
+
+We have clear delineations of functionality, but only a few at the start.  However, thinking ahead,
+this can be a pluggable suite of products and services.  Currently these services are implemented or are in the works:
+
+- Client - the web application 
+- server - generic name that will change once there are a variety of services.  The server is a rest api that uses MongoDB.  Mongo so far has collections for:
+   * users
+   * saved videos from youtube and facebook
+Mongo will have in the future:
+   * all application state such as
+      - learning pages for lack of a better term.  Learning pages are essentially like evernote notes, which can contain any combination of widgets, videos and audio recordings, tablatures, etc.  
+      - Folders to organize resources into a hierarchy
+      - Tags - tags can be applied to any entity
+         * examples - genre:bluegress, riff:key-of-g,starts-on-1,ends-on-5,all-major,major-blues,all-pentatonic
+- ffmpeg_server - this server provides media conversion services.  
+   * this server is standalone and doesn't have a database or any other connected services
+   * on this is installed a simple rest api that other services call call to perform conversions and media acquisition from various online sites such as youtube, facebook and many others that aren't implemented yet.  
+
+In the future, another service to provide is one for audio stem separation
+
+Services can be added and rendered in the UI. 
+
+That's the rough plan anyway.
+
+This plays nicely with the concept of a microservices architecture.  Instead of having one backend service that grows over time with more and more dependencies that can potentially conflict with one another, have several individual services makes sense.  Adding more has no impact on the others.
+
+To make this all happen requires a technology stack that provides features such as:
+- service discovery
+- logging
+- load balancing
+- health monitoring
+
+There are others. 
+
+How best to do this?  That's the question.  So here are some links to start researching:
+- [Hydra](https://blog.risingstack.com/deploying-node-js-microservices-to-aws-using-docker/) This article advocates for using Hydra, which appears to provide for everything needed to deploy NodeJS microservices.  Is it overkill?  
+- [Here](https://thelinuxcode.com/how-to-build-a-serverless-node-js-microservice-on-aws-lambda/) is an article on how to use AWS Lambdas, which talks about an API Gateway that handles service discovery.  It also pushes DynamoDB.  Maybe this can replace Mongo, not sure.  But [here](https://www.mongodb.com/developer/products/atlas/serverless-development-lambda-atlas/) is an article that details how to use Mongo with AWS Lambda.
+- [Another](https://medium.com/@randika/serverless-microservices-with-node-js-and-aws-lambda-build-deploy-34a8c3d80e41xx) AWS Lambda/DynamoDB how to
+- No AWS, but all about Node [microservices](https://dev.to/abeinevincent/how-to-build-deploy-scalable-microservices-with-nodejs-typescript-and-docker-a-comprehesive-guide-2bcc)
+      

--- a/client/src/components/audio_player/index.tsx
+++ b/client/src/components/audio_player/index.tsx
@@ -19,7 +19,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({ audioId, speed = 1.0 }
 
     useEffect(() => {
         if (audioId && audioRef.current) {
-            audioRef.current.src = `${API_CONFIG.SERVER.BASE_URL}${API_CONFIG.SERVER.ENDPOINTS.APP}/audio/stream/${audioId}?speed=${speed}`;
+            audioRef.current.src = `${API_CONFIG.SERVER.BASE_URL}${API_CONFIG.SERVER.ENDPOINTS.AUDIO}/stream/${audioId}?speed=${speed}`;
             audioRef.current.load();
         }
     }, [audioId, speed]);
@@ -29,7 +29,9 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({ audioId, speed = 1.0 }
             if (isPlaying) {
                 audioRef.current.pause();
             } else {
-                audioRef.current.play();
+                audioRef.current.play().catch(error => {
+                    console.error('Error playing audio:', error);
+                });
             }
             setIsPlaying(!isPlaying);
         }
@@ -77,6 +79,7 @@ export const AudioPlayer: React.FC<AudioPlayerProps> = ({ audioId, speed = 1.0 }
                         onTimeUpdate={handleTimeUpdate}
                         onLoadedMetadata={handleLoadedMetadata}
                         onEnded={() => setIsPlaying(false)}
+                        onError={(e) => console.error('Audio error:', e)}
                         style={{ display: 'none' }}
                     />
                 </>

--- a/client/src/components/video_player/index.tsx
+++ b/client/src/components/video_player/index.tsx
@@ -13,7 +13,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({ videoId }) => {
 
     useEffect(() => {
         if (videoId && videoRef.current) {
-            const videoUrl = `${API_CONFIG.SERVER.BASE_URL}${API_CONFIG.SERVER.ENDPOINTS.APP}/videos/${videoId}`;
+            const videoUrl = `${API_CONFIG.SERVER.BASE_URL}${API_CONFIG.SERVER.ENDPOINTS.VIDEOS}/videos/${videoId}`;
             videoRef.current.src = videoUrl;
             videoRef.current.load();
         }

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -8,7 +8,11 @@ export const API_CONFIG = {
     ENDPOINTS: {
       API: '/api',
       APP: '/api/app',
-      FACEBOOK: '/api/fb'
+      FACEBOOK: '/api/fb',
+      YOUTUBE: '/api/videos/youtube',
+      REELS: '/api/reels',
+      AUDIO: '/api/audio',
+      VIDEOS: '/api/videos'
     }
   },
   
@@ -17,7 +21,9 @@ export const API_CONFIG = {
     BASE_URL: ffmpegBaseUrl || 'http://localhost:8080',
     ENDPOINTS: {
       HEALTH: '/ping',
-      CONVERSIONS: '/convert'
+      CONVERSIONS: '/convert',
+      YOUTUBE: '/youtube/download',
+      FACEBOOK: '/facebook/download'
     }
   }
 } as const;

--- a/client/src/hooks/useAudioApi.ts
+++ b/client/src/hooks/useAudioApi.ts
@@ -13,7 +13,7 @@ export const useAudioApi = () => {
       setError(null);
 
       const response = await fetch(
-        `${API_CONFIG.SERVER.BASE_URL}${API_CONFIG.SERVER.ENDPOINTS.APP}/audio`
+        `${API_CONFIG.SERVER.BASE_URL}${API_CONFIG.SERVER.ENDPOINTS.AUDIO}/`
       );
 
       if (!response.ok) {

--- a/client/src/hooks/useVideoApi.ts
+++ b/client/src/hooks/useVideoApi.ts
@@ -13,7 +13,7 @@ export const useVideoApi = () => {
       setError(null);
 
       const response = await fetch(
-        `${API_CONFIG.SERVER.BASE_URL}${API_CONFIG.SERVER.ENDPOINTS.APP}/videos`
+        `${API_CONFIG.SERVER.BASE_URL}${API_CONFIG.SERVER.ENDPOINTS.VIDEOS}/videos`
       );
 
       if (!response.ok) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,74 @@
 # Use root/example as user/password credentials
-version: '3.1'
+version: '3.8'
 
 services:
-
-  mongo:
-    image: mongo
-    restart: always
-    command: mongod --auth
-    container_name: mongo
+  # MongoDB Service
+  mongodb:
+    image: mongo:latest
+    container_name: mongodb
     ports:
-      - '27017-27019:27017-27019'
-    environment:
-      - MONGO_INITDB_DATABASE=guitar-app
-      - MONGO_INITDB_ROOT_USERNAME=admin
-      - MONGO_INITDB_ROOT_PASSWORD=root
+      - "27017:27017"
     volumes:
-      - mongodbdata:/data/db
-      - ./docker_data/init-mongo.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
-
-  mongo-express:
-    image: mongo-express
-    restart: always
-    ports:
-      - 8081:8081
+      - mongodb_data:/data/db
     environment:
-      ME_CONFIG_MONGODB_ADMINUSERNAME: admin
-      ME_CONFIG_MONGODB_ADMINPASSWORD: root
-      ME_CONFIG_MONGODB_URL: mongodb://admin:root@mongo:27017/
-      ME_CONFIG_BASICAUTH: false
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=example
+    networks:
+      - app-network
+
+  # Main Server Service
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    container_name: server
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./server:/app
+      - /app/node_modules
+    environment:
+      - NODE_ENV=development
+      - MONGO_URI=mongodb://root:example@mongodb:27017
+      - SERVICE_NAME=server
+    depends_on:
+      - mongodb
+    networks:
+      - app-network
+
+  # FFmpeg Server Service
+  ffmpeg_server:
+    build:
+      context: ./ffmpeg_server
+      dockerfile: Dockerfile
+    container_name: ffmpeg_server
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./ffmpeg_server:/app
+      - /app/node_modules
+    environment:
+      - NODE_ENV=development
+      - MONGO_URI=mongodb://root:example@mongodb:27017
+      - SERVICE_NAME=ffmpeg_server
+    depends_on:
+      - mongodb
+    networks:
+      - app-network
+
+  # Service Discovery (Consul for local development)
+  consul:
+    image: consul:latest
+    container_name: consul
+    ports:
+      - "8500:8500"
+    command: agent -server -bootstrap -ui -client=0.0.0.0
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
 
 volumes:
-  mongodbdata:
-    driver: local
+  mongodb_data:

--- a/ffmpeg_server/docker-compose.yaml
+++ b/ffmpeg_server/docker-compose.yaml
@@ -26,5 +26,5 @@ services:
       context: .
       dockerfile: yt-dlp.Dockerfile
     volumes:
-      - './data/youtube:/app/data/youtube'
+      - './data/downloads:/app/data/downloads'
     restart: unless-stopped

--- a/ffmpeg_server/src/routes/facebook.ts
+++ b/ffmpeg_server/src/routes/facebook.ts
@@ -1,0 +1,65 @@
+import { Router } from 'express';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import crypto from 'crypto';
+
+const execAsync = promisify(exec);
+const router = Router();
+
+router.post('/download', async (req, res) => {
+    try {
+        const { url } = req.body;
+        
+        if (!url) {
+            return res.status(400).json({ error: 'URL is required' });
+        }
+
+        const downloadsDir = '/app/data/downloads';
+
+        const timestamp = Date.now();
+        const randomString = crypto.randomBytes(4).toString('hex');
+        const reelDownloadFile = `reel_${timestamp}_${randomString}.mp4`;
+        const reelDownloadFileWithPath = `${downloadsDir}/${reelDownloadFile}`;
+        const downloadOptions = `-f "worst[ext=mp4]" --merge-output-format mp4 --no-playlist --no-warnings -o "` + reelDownloadFileWithPath + `"`;
+        
+        // Execute yt-dlp command to download the Facebook Reel with specific format options
+        const command = `docker exec yt-dlp yt-dlp ${downloadOptions} "${url}"`;
+
+        try {
+            await execAsync(command);
+        } catch (execError: any) {
+            // Clean up any partial download
+            try {
+                await fs.promises.unlink(reelDownloadFileWithPath);
+            } catch (unlinkError) {
+                console.error('Error cleaning up partial download:', unlinkError);
+            }
+            
+            // Include stderr in the error response
+            return res.status(500).json({ 
+                error: 'Failed to download video',
+                details: execError.stderr || execError.message
+            });
+        }
+
+        // Read the downloaded file
+        const videoBuffer = await fs.promises.readFile(reelDownloadFileWithPath);
+
+        // Clean up
+        await fs.promises.unlink(reelDownloadFileWithPath);
+
+        // Send the video
+        res.set('Content-Type', 'video/mp4');
+        res.send(videoBuffer);
+
+    } catch (error) {
+        console.error('Error in Facebook download route:', error);
+        res.status(500).json({ 
+            error: 'Failed to download video',
+            details: error instanceof Error ? error.message : String(error)
+        });
+    }
+});
+
+export default router; 

--- a/ffmpeg_server/src/routes/index.ts
+++ b/ffmpeg_server/src/routes/index.ts
@@ -1,9 +1,11 @@
 import healthRouter from './health';
 import conversionsRouter from './conversions';
 import youtubeRouter from './youtube';
+import facebookRouter from './facebook';
 
 export {
     healthRouter,
     conversionsRouter,
-    youtubeRouter
+    youtubeRouter,
+    facebookRouter
 }; 

--- a/ffmpeg_server/src/server.ts
+++ b/ffmpeg_server/src/server.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import { healthRouter, conversionsRouter, youtubeRouter } from './routes';
+import { healthRouter, conversionsRouter, youtubeRouter, facebookRouter } from './routes';
 
 // Load environment variables
 dotenv.config();
@@ -17,6 +17,7 @@ app.use(express.json());
 app.use('/', healthRouter);
 app.use('/', conversionsRouter);
 app.use('/youtube', youtubeRouter);
+app.use('/facebook', facebookRouter);
 
 app.listen(PORT, HOST, () => {
     console.log(`Server running on http://${HOST}:${PORT}`);

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,17 @@
+# Development stage
+FROM node:18-alpine AS development
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install
+COPY . .
+EXPOSE 3000
+CMD ["yarn", "dev"]
+
+# Production stage
+FROM node:18-alpine AS production
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --production
+COPY . .
+EXPOSE 3000
+CMD ["yarn", "start"] 

--- a/server/package.json
+++ b/server/package.json
@@ -2,10 +2,10 @@
   "name": "audio-app-server",
   "version": "1.0.0",
   "description": "Server for audio application",
-  "main": "dist/server.js",
+  "main": "dist/index.js",
   "scripts": {
-    "start": "node dist/server.js",
-    "dev": "ts-node-dev --respawn src/server.ts",
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev --respawn src/index.ts",
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -20,7 +20,8 @@
     "form-data": "^4.0.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.1.1",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@types/axios": "^0.14.4",
@@ -33,6 +34,7 @@
     "@types/jsonwebtoken": "^9.0.5",
     "@types/multer": "^1.4.11",
     "@types/node": "^20.11.16",
+    "@types/uuid": "^10.0.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,11 +1,14 @@
+// Load environment variables first
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load environment variables from the server directory
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
 import express from 'express';
 import mongoose from 'mongoose';
 import cors from 'cors';
-import dotenv from 'dotenv';
 import { appRouter, facebookRouter, audioRouter, userRouter, videoRouter } from './routes';
-
-// Load environment variables
-dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -23,13 +26,13 @@ app.use('/api/users', userRouter);
 app.use('/api/videos', videoRouter);
 
 // Error handling middleware
-app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
+app.use((err: Error, _req: express.Request, res: express.Response, next: express.NextFunction) => {
     console.error(err.stack);
     res.status(500).json({ error: 'Something went wrong!' });
 });
 
 // Connect to MongoDB
-const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://sellis:sellis@localhost:27017/guitar-app';
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/guitar-app';
 
 mongoose.connect(MONGODB_URI)
     .then(() => {

--- a/server/src/models/DownloadedReel.ts
+++ b/server/src/models/DownloadedReel.ts
@@ -1,0 +1,30 @@
+import mongoose from 'mongoose';
+
+const downloadedReelSchema = new mongoose.Schema({
+    title: {
+        type: String,
+        required: true
+    },
+    originalUrl: {
+        type: String,
+        required: true
+    },
+    filename: {
+        type: String,
+        required: true
+    },
+    path: {
+        type: String,
+        required: true
+    },
+    gridfsId: {
+        type: mongoose.Schema.Types.ObjectId,
+        required: true
+    },
+    createdAt: {
+        type: Date,
+        default: Date.now
+    }
+});
+
+export const DownloadedReel = mongoose.model('DownloadedReel', downloadedReelSchema); 

--- a/server/src/routes/audio_routes.ts
+++ b/server/src/routes/audio_routes.ts
@@ -9,7 +9,7 @@ const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
 // Get audio file information
-router.get('/audio/info/:id', async (req: Request, res: Response) => {
+router.get('/info/:id', async (req: Request, res: Response) => {
     try {
         if (!mongoose.connection.readyState) {
             return res.status(503).json({ error: 'Database not ready' });
@@ -41,7 +41,7 @@ router.get('/audio/info/:id', async (req: Request, res: Response) => {
 });
 
 // Get audio content directly
-router.get('/audio/:id', async (req: Request, res: Response) => {
+router.get('/:id', async (req: Request, res: Response) => {
     try {
         if (!mongoose.connection.readyState) {
             return res.status(503).json({ error: 'Database not ready' });
@@ -74,7 +74,7 @@ router.get('/audio/:id', async (req: Request, res: Response) => {
 });
 
 // Stream audio with speed control
-router.get('/audio/stream/:id', async (req: Request, res: Response) => {
+router.get('/stream/:id', async (req: Request, res: Response) => {
     try {
         if (!mongoose.connection.readyState) {
             return res.status(503).json({ error: 'Database not ready' });
@@ -121,7 +121,7 @@ router.get('/audio/stream/:id', async (req: Request, res: Response) => {
 });
 
 // List all audio files
-router.get('/audio', async (_req: Request, res: Response) => {
+router.get('/', async (_req: Request, res: Response) => {
     try {
         if (!mongoose.connection.readyState) {
             return res.status(503).json({ error: 'Database not ready' });
@@ -151,7 +151,7 @@ router.get('/audio', async (_req: Request, res: Response) => {
 });
 
 // Upload audio file
-router.post('/audio', (req: any, res: any) => {
+router.post('/', (req: any, res: any) => {
     const uploadMiddleware = upload.single('file');
     
     uploadMiddleware(req as any, res as any, async (err: any) => {
@@ -223,7 +223,7 @@ router.post('/audio', (req: any, res: any) => {
 });
 
 // Delete audio
-router.delete('/audio/:id', async (req: Request, res: Response) => {
+router.delete('/:id', async (req: Request, res: Response) => {
     try {
         if (!mongoose.connection.readyState) {
             return res.status(503).json({ error: 'Database not ready' });

--- a/server/src/types/facebook.ts
+++ b/server/src/types/facebook.ts
@@ -1,11 +1,3 @@
-export interface FacebookReel {
-    id: string;
-    title: string;
-    url: string;
-    downloaded: boolean;
-    createdAt: string;
-}
-
 export interface DownloadReelRequest {
     url: string;
     title?: string;

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -246,6 +246,11 @@
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
+"@types/uuid@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
 "@types/webidl-conversions@*":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz#1306dbfa53768bcbcfc95a1c8cde367975581859"
@@ -1705,6 +1710,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/shared/src/config.ts
+++ b/shared/src/config.ts
@@ -1,9 +1,4 @@
 // Environment configuration
-const ENV = {
-  API_BASE_URL: 'http://localhost:3001',
-  FFMPEG_BASE_URL: 'http://localhost:8080'
-};
-
 export const API_CONFIG = {
   // Main server API
   SERVER: {


### PR DESCRIPTION
Added facebook reel downloading.

Reorganized the endpoint names some but the project is getting confusing.  Hard to keep all the moving parts straight.

There is an ffmpeg endpoint to download a facebook reel, but it may not require a dedicated set of endpoints to make work, as downloading a youtube video seems to no different.  Originally there were to be separate endpoints for facebook because I intended to use the facebook api.  The ffmpeg endpoint downloads the video and returns it to the caller, with no save.

The server endpoint calls ffmpeg and saves to the mongo.  This is going to change quickly because in order to stream while changing speed, the docker container needs ffmpeg installed.  So either ffmpeg gets rolled into server or vice versa.  The ffmpeg container needs to get content video content so it can be streamed and transformed.

